### PR TITLE
"NameError" in spec/scrabble_spec.rb:4 due to a class name not surrounded by quote

### DIFF
--- a/spec/scrabble_spec.rb
+++ b/spec/scrabble_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require_relative '../lib/scrabble_word'
 
-describe ScrabbleWord do
+describe "ScrabbleWord" do
   describe "#score" do
     it "scores words with a single letter" do
       word = ScrabbleWord.new("a")


### PR DESCRIPTION
A class name without quote causes a "NameError" in `spec/scrabble_spec.rb:4`. Therefore I surrounded it with a quote.

```
$ rspec
/Users/masa/wdi/exercises/scrabbler/spec/scrabble_spec.rb:4:in `<top (required)>': uninitialized constant ScrabbleWord (NameError)
...
```
